### PR TITLE
fix (CSRF token): disable CSRF token in 'shield.js'

### DIFF
--- a/src/adonisjs/config/shield.js
+++ b/src/adonisjs/config/shield.js
@@ -132,7 +132,7 @@ module.exports = {
   |
   */
   csrf: {
-    enable: true,
+    enable: false,
     methods: ['POST', 'PUT', 'DELETE'],
     filterUris: [],
     cookieOptions: {


### PR DESCRIPTION
There was an error happening when trying to update case settings. We disabled it for now, until there's a solution for it.